### PR TITLE
Forza charset utf-8 per connessione al DB.

### DIFF
--- a/DB.php
+++ b/DB.php
@@ -12,7 +12,7 @@ class MyFw_DB extends PDO {
         // get Config Application
         $appConfig = Zend_Registry::get('appConfig');
         $dbParams = $appConfig->database->params;
-        $dsn = 'mysql:host='.$dbParams->host.';dbname='.$dbParams->dbname;
+        $dsn = 'mysql:host='.$dbParams->host.';dbname='.$dbParams->dbname.';charset=utf8';
         $options = array();
         parent::__construct($dsn, $dbParams->username, $dbParams->password, $options);
         $this->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_WARNING);


### PR DESCRIPTION
Probabilmente è un parametro che dovrebbe essere reso configurabile.
Ma è anche vero che utf-8 è un ottimo default nel 99% dei casi,
quindi può essere comunque ragionevole forzarlo nel codice ed evitare
problemi di codifica nella maggior parte dei casi.

Closes iGruppi/iGruppi#88
