### PR TITLE
fix per filter_input(INPUT_SERVER, ...) ritorna null

### DIFF
--- a/ControllerFront.php
+++ b/ControllerFront.php
@@ -28,7 +28,7 @@ class MyFw_ControllerFront {
         self::$instance = $this;
 
         // start Router class
-        $this->_router = new MyFw_Router(filter_input(INPUT_SERVER, "REQUEST_URI"));
+        $this->_router = new MyFw_Router($_SERVER["REQUEST_URI"]);
         
     }
     


### PR DESCRIPTION
È un vecchio bug di PHP:
https://bugs.php.net/bug.php?id=49184

Dal report non è chiaro, ma il bug si manifesta anche quando PHP è usato
in modalità CGI o FastCGI. Data la sempre maggiore diffusione di
provider che usano http://php.net/manual/en/install.fpm.php , usare
filter_input() per leggere i valori in $_SERVER[] spesso crea problemi.

Per aggirare il problema ci sono diversi modi:
- https://github.com/xwp/stream/issues/254
- http://stackoverflow.com/a/27665786/453605

Ma in questo caso, si può semplicemente usare $_SERVER[] perché non
stiamo applicando nessun filtro, quindi l'uso di filter_input() è
equivalente all'accesso diretto alla variabile.
